### PR TITLE
Options to turn off attitude dispersion

### DIFF
--- a/montecarlo/configs/params.yaml
+++ b/montecarlo/configs/params.yaml
@@ -135,11 +135,20 @@ initialization:
      AOP : 63 # [deg]
      AOP_dev : 20 # [%]
 
-     true_anomaly : 0 # [deg] -> Placeholder not accessed
+     # If disperse_true_anomaly is True, true anomaly is randomly sampled between 0 and 360
+     # If False, the nominal_true_anomaly is chosen across trials
+     disperse_true_anomaly : True
+     true_anomaly : 0 # [deg] # Only accessed iff disperse_true_anomaly is False
 
-     initial_attitude : [1,0,0,0] # -> Placeholder not accessed
+     # If disperse_initial_attitude is True, initial attitude is randomly sampled
+     # If False, the nominal_initial_attitude is chosen across trials
+     disperse_initial_attitude : True
+     initial_attitude : [1,0,0,0] # only accessed iff disperse_initial_attitude is False
 
-     initial_angular_rate : [0.2,0.3,0.2] # [rad/s] -> Placeholder not accessed
+     # If disperse_initial_angular_rate is True, initial angular rate is randomly sampled
+     # If False, the nominal_initial_angular_rate is chosen across trials
+     disperse_initial_angular_rate : True
+     initial_angular_rate : [0.2,0.3,0.2] # [rad/s] accessed iff disperse_initial_angular_rate is True
      initial_angular_rate_bound : 0.5 # Max initial angular rate about any axis [rad/s]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 basemap
 psutil
 pyigrf
+flask

--- a/simulation_utils/ParameterParser.cpp
+++ b/simulation_utils/ParameterParser.cpp
@@ -100,13 +100,31 @@ Simulation_Parameters::Simulation_Parameters(std::string filename, int trial_num
     inclination = inclination_dist(dev);
     RAAN = RAAN_dist(dev);
     AOP = AOP_dist(dev);
-    true_anomaly = true_anomaly_dist(dev);
+
+    bool disperse_true_anomaly = params["initialization"]["disperse_true_anomaly"].as<bool>();
+    if (disperse_true_anomaly) {
+        true_anomaly = true_anomaly_dist(dev);
+    } else {
+        true_anomaly = params["initialization"]["true_anomaly"].as<double>();
+    }
     
     // Satellite Attitude Initialization
-    initial_attitude = Vector4::NullaryExpr([&](){return initial_attitude_dist(dev);});
-    initial_attitude = initial_attitude/initial_attitude.norm();
+    bool disperse_initial_attitude = params["initialization"]["disperse_initial_attitude"].as<bool>();
+    if (disperse_initial_attitude) {
+        initial_attitude = Vector4::NullaryExpr([&](){return initial_attitude_dist(dev);});
+        initial_attitude = initial_attitude/initial_attitude.norm();
+    } else {
+        initial_attitude = Eigen::Map<Vector4>(params["initialization"]["initial_attitude"].as<std::vector<double>>().data());
+    }
 
-    initial_angular_rate = Vector3::NullaryExpr([&](){return initial_angular_rate_dist(dev);});
+    bool disperse_initial_angular_rate = params["initialization"]["disperse_initial_angular_rate"].as<bool>();
+    if (disperse_initial_angular_rate) {
+        initial_angular_rate = Vector3::NullaryExpr([&](){return initial_angular_rate_dist(dev);});
+    } else {
+        initial_angular_rate = Eigen::Map<Vector3>(params["initialization"]["initial_angular_rate"].as<std::vector<double>>().data());
+    }
+
+    // Sim Start Time
     sim_start_time = sim_start_time_dist(dev);
     
     // Populate State Vector


### PR DESCRIPTION
Adds the following:
- Options to turn off dispersions for true anomaly, initial attitude and initial angular rate
- Also adds Flask to the dependency list to run web visualizer